### PR TITLE
feat(common): Add common application layer

### DIFF
--- a/Commons/Common.Application/Abstractions/Messaging/Commands/ICommand.cs
+++ b/Commons/Common.Application/Abstractions/Messaging/Commands/ICommand.cs
@@ -1,0 +1,12 @@
+﻿using Common.Application.Models.Results;
+using MediatR;
+
+namespace Common.Application.Abstractions.Messaging.Commands;
+
+public interface ICommand : IRequest<OperationResult>
+{
+}
+
+public interface ICommand<TData> : IRequest<OperationResult<TData>>
+{
+}

--- a/Commons/Common.Application/Abstractions/Messaging/Commands/ICommandHandler.cs
+++ b/Commons/Common.Application/Abstractions/Messaging/Commands/ICommandHandler.cs
@@ -1,0 +1,12 @@
+﻿using Common.Application.Models.Results;
+using MediatR;
+
+namespace Common.Application.Abstractions.Messaging.Commands;
+
+public interface ICommandHandler<TCommand> : IRequestHandler<TCommand, OperationResult> where TCommand : ICommand
+{
+}
+
+public interface ICommandHandler<TCommand, TResponseData> : IRequestHandler<TCommand, OperationResult<TResponseData>> where TCommand : ICommand<TResponseData>
+{
+}

--- a/Commons/Common.Application/Behaviors/ValidationBehavior.cs
+++ b/Commons/Common.Application/Behaviors/ValidationBehavior.cs
@@ -1,0 +1,47 @@
+﻿using Common.Application.Abstractions.Messaging.Commands;
+using MediatR;
+using FluentValidation;
+using Common.Domain.Exceptions;
+using ValidationException = Common.Domain.Exceptions.ValidationException;
+namespace Common.Application.Behaviors;
+
+internal sealed class ValidationBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse> where TRequest : ICommand
+{
+    private readonly IEnumerable<IValidator<TRequest>> _validators;
+
+    public ValidationBehavior(IEnumerable<IValidator<TRequest>> validators)
+    {
+        _validators = validators;
+    }
+
+
+    public async Task<TResponse> Handle(
+        TRequest request,
+        RequestHandlerDelegate<TResponse> next,
+        CancellationToken cancellationToken)
+    {
+        if (!_validators.Any())
+        {
+            return await next(cancellationToken);
+        }
+        var context = new ValidationContext<TRequest>(request);
+
+        var validationResults = await Task.WhenAll(
+            _validators.Select(v => v.ValidateAsync(context, cancellationToken)));
+
+        // حالا ما یک لیست ساختاریافته از خطاها داریم
+        var errors = validationResults
+            .SelectMany(r => r.Errors)
+            .Where(f => f != null)
+            .Select(f => new ValidationError(f.PropertyName, f.ErrorMessage))
+            .Distinct()
+            .ToList();
+
+        if (errors.Any())
+        {
+            throw new ValidationException(errors);
+        }
+
+        return await next(cancellationToken);
+    }
+}

--- a/Commons/Common.Application/Common.Application.csproj
+++ b/Commons/Common.Application/Common.Application.csproj
@@ -6,4 +6,14 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="FluentValidation" Version="12.0.0" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.0.0" />
+    <PackageReference Include="MediatR" Version="13.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Common.Domain\Common.Domain.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/Commons/Common.Application/Models/Results/OperationResult.cs
+++ b/Commons/Common.Application/Models/Results/OperationResult.cs
@@ -1,0 +1,70 @@
+﻿namespace Common.Application.Models.Results;
+
+public class OperationResult
+{
+    public string Message { get; private set; }
+    public OperationResultStatus Status { get; private set; }
+
+    protected OperationResult(string message, OperationResultStatus status)
+    {
+        Message = message;
+        Status = status;
+    }
+
+
+    public static OperationResult Success(string message = "عملیات با موفقیت انجام شد")
+    {
+        return new OperationResult(message, OperationResultStatus.Success);
+    }
+    public static OperationResult Warning(string message = "هشدار!")
+    {
+        return new OperationResult(message, OperationResultStatus.Warning);
+    }
+
+    public static OperationResult Error(string message = "عملیات با شکست مواجه شد")
+    {
+        return new OperationResult(message, OperationResultStatus.Error);
+    }
+
+    public static OperationResult NotFound(string message = "اطلاعات یافت نشد")
+    {
+        return new OperationResult(message, OperationResultStatus.NotFound);
+    }
+}
+
+public class OperationResult<TData> : OperationResult
+{
+    public TData? Data { get; private set; }
+
+    private OperationResult(string message, OperationResultStatus status, TData? data)
+        : base(message, status)
+    {
+        Data = data;
+    }
+
+    public static OperationResult<TData> Success(TData data, string message = "عملیات با موفقیت انجام شد")
+    {
+        return new OperationResult<TData>(message, OperationResultStatus.Success, data);
+    }
+    public static new OperationResult<TData> Warning(string message = "هشدار!")
+    {
+        return new OperationResult<TData>(message, OperationResultStatus.Warning, default);
+    }
+    public static new OperationResult<TData> Error(string message = "عملیات با شکست مواجه شد")
+    {
+        return new OperationResult<TData>(message, OperationResultStatus.Error, default);
+    }
+
+    public static new OperationResult<TData> NotFound(string message = "اطلاعات یافت نشد")
+    {
+        return new OperationResult<TData>(message, OperationResultStatus.NotFound, default);
+    }
+}
+
+public enum OperationResultStatus
+{
+    Success,
+    Error,
+    NotFound,
+    Warning
+}

--- a/Commons/Common.Domain/Exceptions/ValidationException.cs
+++ b/Commons/Common.Domain/Exceptions/ValidationException.cs
@@ -1,0 +1,11 @@
+﻿namespace Common.Domain.Exceptions;
+
+public record ValidationError(string PropertyName, string ErrorMessage);
+public class ValidationException : Exception
+{
+    public IReadOnlyCollection<ValidationError> Errors { get; }
+    public ValidationException(IReadOnlyCollection<ValidationError> errors) : base("Validation Failed")
+    {
+        Errors = errors;
+    }
+}


### PR DESCRIPTION
This commit introduces the Common.Application project, which provides shared abstractions and behaviors for the application layer.

- Defines ICommand and ICommandHandler interfaces to standardize the CQRS pattern.
- Implements a robust, immutable OperationResult pattern for handling use case outcomes.
- Adds a MediatR ValidationBehavior for automatic and centralized command validation.
- Includes a custom ValidationException for structured error handling.