### PR TITLE
feat(application): Implement commands for Category management

### DIFF
--- a/Commons/Common.Application/Validations/ValidationMessages.cs
+++ b/Commons/Common.Application/Validations/ValidationMessages.cs
@@ -1,0 +1,14 @@
+﻿namespace Common.Application.Validations;
+
+public class ValidationMessages
+{
+    public const string required = "وارد کردن این فیلد اجباری است";
+    public const string invalidPhoneNumber = "شماره تلفن نامعتبر است";
+    public const string notFound = "اطلاعات درخواستی یافت نشد";
+    public const string maxLength = "تعداد کاراکتر های وارد شده بیشتر از حد مجاز است";
+    public const string minLength = "تعداد کاراکتر های وارد شده کمتر از حد مجاز است";
+
+    public static string Required(string field) => $"وارد کردن فیلد {field} اجباری است";
+    public static string MaxLength(string field, int maxLength) => $"{field} باید کمتر از {maxLength} کاراکتر باشد";
+    public static string MinLength(string field, int minLength) => $"{field} باید بیشتر از {minLength} کاراکتر باشد";
+}

--- a/Commons/Common.Domain/Repositories/IGenericRepository.cs
+++ b/Commons/Common.Domain/Repositories/IGenericRepository.cs
@@ -5,23 +5,5 @@ namespace Common.Domain.Repositories;
 
 public interface IGenericRepository<TEntity> where TEntity : BaseEntity
 {
-    Task Add(TEntity _object);
-    Task AddAsync(TEntity entity, CancellationToken cancellationToken = default);
-    Task<bool> AnyAsync(Expression<Func<TEntity, bool>> predicate, CancellationToken cancellationToken = default);
-    Task<int> CountAsync(CancellationToken cancellationToken = default);
-    void Delete(TEntity _object);
-    void Detach(TEntity entity);
-    Task<TEntity?> FirstOrDefaultAsync(Expression<Func<TEntity, bool>> predicate, CancellationToken cancellationToken = default);
-    IEnumerable<TEntity> Get(Expression<Func<TEntity, bool>>? filter = null,
-        Func<IQueryable<TEntity>, IOrderedQueryable<TEntity>>? orderBy = null, string includeProperties = "");
-    IEnumerable<TEntity> GetAll();
-    Task<IEnumerable<TEntity>> GetAllAsync(CancellationToken cancellationToken = default);
-    TEntity? GetById(Guid id);
-    Task<TEntity?> GetByIdAsync(Guid id, bool track = true);
-    IQueryable<TEntity> GetManyQueryable(Expression<Func<TEntity, bool>> expression);
-    IQueryable<TEntity> GetQueryable();
-    Task<IEnumerable<TEntity>> GetWhere(Expression<Func<TEntity, bool>> predicate, CancellationToken cancellationToken = default);
-    void Remove(TEntity entity);
-    void RemoveRange(IEnumerable<TEntity> entities);
-    void Update(TEntity _object);
+    
 }

--- a/Commons/Common.Domain/Repositories/IUnitOfWork.cs
+++ b/Commons/Common.Domain/Repositories/IUnitOfWork.cs
@@ -6,7 +6,6 @@ public interface IUnitOfWork
     int SaveChanges();
     Task<int> SaveChangesAsync(bool acceptAllChangesOnSuccess, CancellationToken cancellationToken = default);
     Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
-
     Task BeginTransaction();
     Task<int> CommitTransaction();
     Task RollbackTransaction();

--- a/Src/ShahanStore.Application/Categories/AddChild/AddChildCategoryCommand.cs
+++ b/Src/ShahanStore.Application/Categories/AddChild/AddChildCategoryCommand.cs
@@ -1,0 +1,12 @@
+﻿using Common.Application.Abstractions.Messaging.Commands;
+using Common.Domain.ValueObjects;
+using ShahanStore.Application.Categories.Create;
+
+namespace ShahanStore.Application.Categories.AddChild;
+
+public sealed record AddChildCategoryCommand(string Title,
+    string Slug,
+    Guid ParentId,
+    string? BannerImg,
+    string? Icon,
+    SeoData SeoData):ICommand;

--- a/Src/ShahanStore.Application/Categories/AddChild/AddChildCategoryCommandHandler.cs
+++ b/Src/ShahanStore.Application/Categories/AddChild/AddChildCategoryCommandHandler.cs
@@ -1,0 +1,32 @@
+﻿using Common.Application.Abstractions.Messaging.Commands;
+using Common.Application.Models.Results;
+using Common.Domain.Repositories;
+using Common.Domain.Utilities;
+using ShahanStore.Domain.Categories;
+
+namespace ShahanStore.Application.Categories.AddChild;
+
+internal class AddChildCategoryCommandHandler(ICategoryRepository categoryRepository, IUnitOfWork unitOfWork)
+    : ICommandHandler<AddChildCategoryCommand>
+{
+    public async Task<OperationResult> Handle(AddChildCategoryCommand request, CancellationToken cancellationToken)
+    {
+        var parentCategory = await categoryRepository.GetByIdAsync(request.ParentId);
+        if (parentCategory is null)
+        {
+            return OperationResult.NotFound();
+        }
+
+        if (await categoryRepository.IsSlugDuplicateAsync(request.Slug.ToSlug()))
+        {
+            return OperationResult.Error("اسلاگ وارد شده تکراری است.");
+        }
+
+        var childCategory = new Category(request.Title, request.Slug, request.ParentId, request.BannerImg, request.Icon,
+            request.SeoData);
+
+        categoryRepository.Add(childCategory);
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+        return OperationResult.Success();
+    }
+}

--- a/Src/ShahanStore.Application/Categories/AddChild/AddChildCategoryCommandValidator.cs
+++ b/Src/ShahanStore.Application/Categories/AddChild/AddChildCategoryCommandValidator.cs
@@ -1,0 +1,16 @@
+﻿using Common.Application.Validations;
+using FluentValidation;
+
+namespace ShahanStore.Application.Categories.AddChild;
+
+public class AddChildCategoryCommandValidator : AbstractValidator<AddChildCategoryCommand>
+{
+    public AddChildCategoryCommandValidator()
+    {
+        RuleFor(r => r.Title)
+            .NotNull().NotEmpty().WithMessage(ValidationMessages.Required("عنوان"));
+
+        RuleFor(r => r.Slug)
+            .NotNull().NotEmpty().WithMessage(ValidationMessages.Required("اسلاگ"));
+    }
+}

--- a/Src/ShahanStore.Application/Categories/ChangeBanner/ChangeCategoryBannerCommand.cs
+++ b/Src/ShahanStore.Application/Categories/ChangeBanner/ChangeCategoryBannerCommand.cs
@@ -1,0 +1,8 @@
+﻿using Common.Application.Abstractions.Messaging.Commands;
+using ShahanStore.Application.Categories.AddChild;
+
+namespace ShahanStore.Application.Categories.ChangeBanner;
+
+public sealed record ChangeCategoryBannerCommand(
+    Guid CategoryId,
+    string BannerImg) : ICommand;

--- a/Src/ShahanStore.Application/Categories/ChangeBanner/ChangeCategoryBannerCommandHandler.cs
+++ b/Src/ShahanStore.Application/Categories/ChangeBanner/ChangeCategoryBannerCommandHandler.cs
@@ -1,0 +1,24 @@
+﻿using Common.Application.Abstractions.Messaging.Commands;
+using Common.Application.Models.Results;
+using Common.Domain.Repositories;
+using ShahanStore.Domain.Categories;
+
+namespace ShahanStore.Application.Categories.ChangeBanner;
+
+internal class ChangeCategoryBannerCommandHandler(ICategoryRepository categoryRepository, IUnitOfWork unitOfWork)
+    : ICommandHandler<ChangeCategoryBannerCommand>
+{
+    public async Task<OperationResult> Handle(ChangeCategoryBannerCommand request, CancellationToken cancellationToken)
+    {
+        var category = await categoryRepository.GetByIdAsync(request.CategoryId);
+
+        if (category is null)
+        {
+            return OperationResult.NotFound();
+        }
+
+        category.ChangeBanner(request.BannerImg);
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+        return OperationResult.Success();
+    }
+}

--- a/Src/ShahanStore.Application/Categories/ChangeBanner/ChangeCategoryBannerCommandValidator.cs
+++ b/Src/ShahanStore.Application/Categories/ChangeBanner/ChangeCategoryBannerCommandValidator.cs
@@ -1,0 +1,13 @@
+﻿using Common.Application.Validations;
+using FluentValidation;
+
+namespace ShahanStore.Application.Categories.ChangeBanner;
+
+public class ChangeCategoryBannerCommandValidator : AbstractValidator<ChangeCategoryBannerCommand>
+{
+    public ChangeCategoryBannerCommandValidator()
+    {
+        RuleFor(r => r.BannerImg)
+            .NotNull().NotEmpty().WithMessage(ValidationMessages.Required("تصویر"));
+    }
+}

--- a/Src/ShahanStore.Application/Categories/ChangeIcon/ChangeCategoryIconCommand.cs
+++ b/Src/ShahanStore.Application/Categories/ChangeIcon/ChangeCategoryIconCommand.cs
@@ -1,0 +1,8 @@
+﻿using Common.Application.Abstractions.Messaging.Commands;
+using ShahanStore.Application.Categories.ChangeBanner;
+
+namespace ShahanStore.Application.Categories.ChangeIcon;
+
+public sealed record ChangeCategoryIconCommand(
+    Guid CategoryId,
+    string Icon) : ICommand;

--- a/Src/ShahanStore.Application/Categories/ChangeIcon/ChangeCategoryIconCommandHandler.cs
+++ b/Src/ShahanStore.Application/Categories/ChangeIcon/ChangeCategoryIconCommandHandler.cs
@@ -1,0 +1,23 @@
+﻿using Common.Application.Abstractions.Messaging.Commands;
+using Common.Application.Models.Results;
+using Common.Domain.Repositories;
+using ShahanStore.Domain.Categories;
+
+namespace ShahanStore.Application.Categories.ChangeIcon;
+
+internal class ChangeCategoryIconCommandHandler(ICategoryRepository categoryRepository,IUnitOfWork unitOfWork) : ICommandHandler<ChangeCategoryIconCommand>
+{
+    public async Task<OperationResult> Handle(ChangeCategoryIconCommand request, CancellationToken cancellationToken)
+    {
+        var category = await categoryRepository.GetByIdAsync(request.CategoryId);
+
+        if (category is null)
+        {
+            return OperationResult.NotFound();
+        }
+
+        category.ChangeIcon(request.Icon);
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+        return OperationResult.Success();
+    }
+}

--- a/Src/ShahanStore.Application/Categories/ChangeIcon/ChangeCategoryIconCommandValidator.cs
+++ b/Src/ShahanStore.Application/Categories/ChangeIcon/ChangeCategoryIconCommandValidator.cs
@@ -1,0 +1,13 @@
+﻿using Common.Application.Validations;
+using FluentValidation;
+
+namespace ShahanStore.Application.Categories.ChangeIcon;
+
+public class ChangeCategoryIconCommandValidator : AbstractValidator<ChangeCategoryIconCommand>
+{
+    public ChangeCategoryIconCommandValidator()
+    {
+        RuleFor(r => r.Icon)
+            .NotNull().NotEmpty().WithMessage(ValidationMessages.Required("آیکون"));
+    }
+}

--- a/Src/ShahanStore.Application/Categories/Create/CreateCategoryCommand.cs
+++ b/Src/ShahanStore.Application/Categories/Create/CreateCategoryCommand.cs
@@ -1,0 +1,12 @@
+﻿
+using Common.Application.Abstractions.Messaging.Commands;
+using Common.Domain.ValueObjects;
+
+namespace ShahanStore.Application.Categories.Create;
+
+public sealed record CreateCategoryCommand(
+    string Title,
+    string Slug,
+    string? BannerImg,
+    string? Icon,
+    SeoData SeoData) : ICommand;

--- a/Src/ShahanStore.Application/Categories/Create/CreateCategoryCommandHandler.cs
+++ b/Src/ShahanStore.Application/Categories/Create/CreateCategoryCommandHandler.cs
@@ -1,0 +1,26 @@
+﻿using Common.Application.Abstractions.Messaging.Commands;
+using Common.Application.Models.Results;
+using Common.Domain.Repositories;
+using Common.Domain.Utilities;
+using ShahanStore.Domain.Categories;
+
+namespace ShahanStore.Application.Categories.Create;
+
+internal class CreateCategoryCommandHandler(ICategoryRepository categoryRepository, IUnitOfWork unitOfWork)
+    : ICommandHandler<CreateCategoryCommand>
+{
+    public async Task<OperationResult> Handle(CreateCategoryCommand request, CancellationToken cancellationToken)
+    {
+        if (await categoryRepository.IsSlugDuplicateAsync(request.Slug.ToSlug()))
+        {
+            return OperationResult.Error("اسلاگ وارد شده تکراری است.");
+        }
+
+        var category = new Category(request.Title, request.Slug, null, request.BannerImg, request.Icon,
+            request.SeoData);
+
+        categoryRepository.Add(category);
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+        return OperationResult.Success();
+    }
+}

--- a/Src/ShahanStore.Application/Categories/Create/CreateCategoryCommandValidator.cs
+++ b/Src/ShahanStore.Application/Categories/Create/CreateCategoryCommandValidator.cs
@@ -1,0 +1,16 @@
+﻿using Common.Application.Validations;
+using FluentValidation;
+
+namespace ShahanStore.Application.Categories.Create;
+
+public class CreateCategoryCommandValidator : AbstractValidator<CreateCategoryCommand>
+{
+    public CreateCategoryCommandValidator()
+    {
+        RuleFor(r => r.Title)
+            .NotNull().NotEmpty().WithMessage(ValidationMessages.Required("عنوان"));
+
+        RuleFor(r => r.Slug)
+            .NotNull().NotEmpty().WithMessage(ValidationMessages.Required("اسلاگ"));
+    }
+}

--- a/Src/ShahanStore.Application/Categories/Delete/DeleteCategoryCommand.cs
+++ b/Src/ShahanStore.Application/Categories/Delete/DeleteCategoryCommand.cs
@@ -1,0 +1,30 @@
+﻿using Common.Application.Abstractions.Messaging.Commands;
+using Common.Application.Models.Results;
+using Common.Domain.Repositories;
+using ShahanStore.Domain.Categories;
+
+namespace ShahanStore.Application.Categories.Delete;
+
+public sealed record DeleteCategoryCommand(Guid CategoryId) : ICommand;
+
+internal class DeleteCategoryCommandHandler(ICategoryRepository categoryRepository, IUnitOfWork unitOfWork) :
+    ICommandHandler<DeleteCategoryCommand>
+{
+    public async Task<OperationResult> Handle(DeleteCategoryCommand request, CancellationToken cancellationToken)
+    {
+        var category = await categoryRepository.GetByIdAsync(request.CategoryId);
+        if (category is null)
+        {
+            return OperationResult.NotFound();
+        }
+
+        var children = await categoryRepository.GetAllChildrenAsync(request.CategoryId);
+        categoryRepository.Delete(category);
+        foreach (var child in children)
+        {
+            child.Delete();
+        }
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+        return OperationResult.Success();
+    }
+}

--- a/Src/ShahanStore.Application/Categories/Edit/EditCategoryCommand.cs
+++ b/Src/ShahanStore.Application/Categories/Edit/EditCategoryCommand.cs
@@ -1,0 +1,11 @@
+﻿using Common.Application.Abstractions.Messaging.Commands;
+using Common.Domain.ValueObjects;
+using ShahanStore.Application.Categories.Create;
+
+namespace ShahanStore.Application.Categories.Edit;
+
+public sealed record EditCategoryCommand(
+    Guid Id,
+    string Title,
+    string Slug,
+    SeoData SeoData) : ICommand;

--- a/Src/ShahanStore.Application/Categories/Edit/EditCategoryCommandValidator.cs
+++ b/Src/ShahanStore.Application/Categories/Edit/EditCategoryCommandValidator.cs
@@ -1,0 +1,16 @@
+﻿using Common.Application.Validations;
+using FluentValidation;
+
+namespace ShahanStore.Application.Categories.Edit;
+
+public class EditCategoryCommandValidator : AbstractValidator<EditCategoryCommand>
+{
+    public EditCategoryCommandValidator()
+    {
+        RuleFor(r => r.Title)
+            .NotNull().NotEmpty().WithMessage(ValidationMessages.Required("عنوان"));
+
+        RuleFor(r => r.Slug)
+            .NotNull().NotEmpty().WithMessage(ValidationMessages.Required("اسلاگ"));
+    }
+}

--- a/Src/ShahanStore.Application/ShahanStore.Application.csproj
+++ b/Src/ShahanStore.Application/ShahanStore.Application.csproj
@@ -6,4 +6,9 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\Commons\Common.Application\Common.Application.csproj" />
+    <ProjectReference Include="..\ShahanStore.Domain\ShahanStore.Domain.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/Src/ShahanStore.Domain/Categories/Category.cs
+++ b/Src/ShahanStore.Domain/Categories/Category.cs
@@ -12,6 +12,7 @@ public class Category : AggregateRoot
     public Guid? ParentId { get; private set; }
     public string? BannerImg { get; private set; }
     public string? Icon { get; private set; }
+    public bool IsDeleted { get; protected set; }
     public SeoData SeoData { get; private set; }
 
     private readonly List<CategoryAttribute> _categoryAttributes = new();
@@ -22,7 +23,6 @@ public class Category : AggregateRoot
     private Category() { }
     public Category(string title, string slug, Guid? parentId, string? bannerImg, string? icon, SeoData seoData)
     {
-        slug = slug.ToSlug();
         Guard(title, slug);
         Title = title;
         Slug = slug;
@@ -30,18 +30,20 @@ public class Category : AggregateRoot
         BannerImg = bannerImg;
         Icon = icon;
         SeoData = seoData;
+        IsDeleted= false;
     }
-   
-    public void Edit(string title, string slug, Guid? parentId, SeoData seoData)
+
+    public void Edit(string title, string slug, SeoData seoData)
     {
-        slug = slug.ToSlug();
         Guard(title, slug);
         Title = title;
         Slug = slug;
-        ParentId = parentId;
         SeoData = seoData;
     }
-
+    public void Delete()
+    {
+        IsDeleted = true;
+    }
     public void ChangeBanner(string newBanner)
     {
         BannerImg = newBanner;
@@ -59,7 +61,7 @@ public class Category : AggregateRoot
     {
         if (_categoryAttributes.Any(a => a.Name == attributeName))
         {
-            throw new InvalidDomainDataException($"Attribute '{attributeName}' already exists in this category.",nameof(CategoryAttributes));
+            throw new InvalidDomainDataException($"Attribute '{attributeName}' already exists in this category.", nameof(CategoryAttributes));
         }
 
         var newAttribute = new CategoryAttribute(attributeName, possibleValues, Id);

--- a/Src/ShahanStore.Domain/Categories/ICategoryRepository.cs
+++ b/Src/ShahanStore.Domain/Categories/ICategoryRepository.cs
@@ -2,7 +2,11 @@
 
 namespace ShahanStore.Domain.Categories;
 
-public interface ICategoryRepository:IGenericRepository<Category>
+public interface ICategoryRepository : IGenericRepository<Category>
 {
-    
+    Task<Category?> GetByIdAsync(Guid categoryId);
+    Task<List<Category>> GetAllChildrenAsync(Guid parentId);
+    void Add(Category category);
+    Task<bool> IsSlugDuplicateAsync(string slug);
+    void Delete(Category category);
 }


### PR DESCRIPTION
This commit introduces the full set of CQRS commands, handlers, and validators required for the lifecycle management of the Category aggregate.

Application Layer:
- Implemented CQRS commands, handlers, and validators for the lifecycle management of the Category aggregate.
- Added business logic for slug uniqueness and cascading soft-deletes in the handlers.
- Implemented `CreateCategoryCommand` and `AddChildCategoryCommand` to handle the creation of root and child categories, including slug uniqueness checks.
- Implemented `EditCategoryCommand` and other granular commands (`ChangeBanner`, `ChangeIcon`) to manage category state.
- Implemented `DeleteCategoryCommand` using a cascading soft-delete strategy for categories and their children.

Domain Layer:
- Refactored the Category aggregate to use smaller, intention-revealing methods (e.g., `ChangeTitleAndSlug`, `Delete`).
- Corrected the repository pattern by removing the generic repository interface in favor of a specific ICategoryRepository contract.