### PR TITLE
feat(persistence): Add EF Core configurations for entities

### DIFF
--- a/Src/ShahanStore.Infrastructure/Configuration/Persistence/Categories/CategoryAttributeConfiguration.cs
+++ b/Src/ShahanStore.Infrastructure/Configuration/Persistence/Categories/CategoryAttributeConfiguration.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using ShahanStore.Domain.Categories;
+
+namespace ShahanStore.Infrastructure.Configuration.Persistence.Categories;
+
+public class CategoryAttributeConfiguration:IEntityTypeConfiguration<CategoryAttribute>
+{
+    public void Configure(EntityTypeBuilder<CategoryAttribute> builder)
+    {
+        builder.ToTable("CategoryAttributes", "category");
+
+        builder.HasKey(b => b.Id);
+
+        builder.Property(b => b.Name)
+            .IsRequired()
+            .HasMaxLength(100);
+    }
+}

--- a/Src/ShahanStore.Infrastructure/Configuration/Persistence/Categories/CategoryConfiguration.cs
+++ b/Src/ShahanStore.Infrastructure/Configuration/Persistence/Categories/CategoryConfiguration.cs
@@ -2,7 +2,7 @@
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using ShahanStore.Domain.Categories;
 
-namespace ShahanStore.Infrastructure.Configuration.Persistence;
+namespace ShahanStore.Infrastructure.Configuration.Persistence.Categories;
 
 public class CategoryConfiguration:IEntityTypeConfiguration<Category>
 {

--- a/Src/ShahanStore.Infrastructure/Configuration/Persistence/OutboxMessages/OutboxMessageConfiguration.cs
+++ b/Src/ShahanStore.Infrastructure/Configuration/Persistence/OutboxMessages/OutboxMessageConfiguration.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using ShahanStore.Infrastructure.BackgroundJobs.Models;
+
+namespace ShahanStore.Infrastructure.Configuration.Persistence.OutboxMessages;
+
+public class OutboxMessageConfiguration:IEntityTypeConfiguration<OutboxMessage>
+{
+    public void Configure(EntityTypeBuilder<OutboxMessage> builder)
+    {
+        builder.ToTable("OutboxMessages", "dbo");
+        builder.HasKey(om => om.Id);
+
+        builder.Property(om => om.Type).IsRequired();
+        builder.Property(om => om.Content).IsRequired();
+
+        builder.HasIndex(om => om.ProcessedOnUtc);
+    }
+}

--- a/Src/ShahanStore.Infrastructure/Migrations/20250720082259_FixEntityConfigurations.Designer.cs
+++ b/Src/ShahanStore.Infrastructure/Migrations/20250720082259_FixEntityConfigurations.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using ShahanStore.Infrastructure.Data;
@@ -12,9 +13,11 @@ using ShahanStore.Infrastructure.Data;
 namespace ShahanStore.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250720082259_FixEntityConfigurations")]
+    partial class FixEntityConfigurations
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Src/ShahanStore.Infrastructure/Migrations/20250720082259_FixEntityConfigurations.cs
+++ b/Src/ShahanStore.Infrastructure/Migrations/20250720082259_FixEntityConfigurations.cs
@@ -1,0 +1,130 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ShahanStore.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class FixEntityConfigurations : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_CategoryAttribute_Categories_CategoryId",
+                table: "CategoryAttribute");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_CategoryAttribute",
+                table: "CategoryAttribute");
+
+            migrationBuilder.EnsureSchema(
+                name: "category");
+
+            migrationBuilder.RenameTable(
+                name: "OutboxMessages",
+                newName: "OutboxMessages",
+                newSchema: "dbo");
+
+            migrationBuilder.RenameTable(
+                name: "CategoryAttribute",
+                newName: "CategoryAttributes",
+                newSchema: "category");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_CategoryAttribute_CategoryId",
+                schema: "category",
+                table: "CategoryAttributes",
+                newName: "IX_CategoryAttributes_CategoryId");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                schema: "category",
+                table: "CategoryAttributes",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_CategoryAttributes",
+                schema: "category",
+                table: "CategoryAttributes",
+                column: "Id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OutboxMessages_ProcessedOnUtc",
+                schema: "dbo",
+                table: "OutboxMessages",
+                column: "ProcessedOnUtc");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_CategoryAttributes_Categories_CategoryId",
+                schema: "category",
+                table: "CategoryAttributes",
+                column: "CategoryId",
+                principalSchema: "dbo",
+                principalTable: "Categories",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_CategoryAttributes_Categories_CategoryId",
+                schema: "category",
+                table: "CategoryAttributes");
+
+            migrationBuilder.DropIndex(
+                name: "IX_OutboxMessages_ProcessedOnUtc",
+                schema: "dbo",
+                table: "OutboxMessages");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_CategoryAttributes",
+                schema: "category",
+                table: "CategoryAttributes");
+
+            migrationBuilder.RenameTable(
+                name: "OutboxMessages",
+                schema: "dbo",
+                newName: "OutboxMessages");
+
+            migrationBuilder.RenameTable(
+                name: "CategoryAttributes",
+                schema: "category",
+                newName: "CategoryAttribute");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_CategoryAttributes_CategoryId",
+                table: "CategoryAttribute",
+                newName: "IX_CategoryAttribute_CategoryId");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "CategoryAttribute",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(100)",
+                oldMaxLength: 100);
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_CategoryAttribute",
+                table: "CategoryAttribute",
+                column: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_CategoryAttribute_Categories_CategoryId",
+                table: "CategoryAttribute",
+                column: "CategoryId",
+                principalSchema: "dbo",
+                principalTable: "Categories",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}


### PR DESCRIPTION
This commit adds the explicit IEntityTypeConfiguration classes for the CategoryAttribute and OutboxMessage entities to ensure correct database mapping and apply specific constraints.

- Added `CategoryAttributeConfiguration` to define the table name and property constraints.
- Added `OutboxMessageConfiguration` to define the table name and a performance-critical index on the `ProcessedOnUtc` column.