### PR TITLE
refactor(category): Decouple command contracts and improve repository

### DIFF
--- a/Commons/Common.Application/Common.Application.csproj
+++ b/Commons/Common.Application/Common.Application.csproj
@@ -1,23 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="12.0.0" />
-    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.0.0" />
-    <PackageReference Include="MediatR" Version="13.0.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="FluentValidation" Version="12.0.0" />
+		<PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.0.0" />
+		<PackageReference Include="MediatR" Version="13.0.0" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Common.Domain\Common.Domain.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Common.Domain\Common.Domain.csproj" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Configuration\" />
-  </ItemGroup>
+	<ItemGroup>
+		<Folder Include="Configuration\" />
+	</ItemGroup>
 
 </Project>

--- a/Commons/Common.Domain/Common.Domain.csproj
+++ b/Commons/Common.Domain/Common.Domain.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="MediatR" Version="13.0.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="MediatR" Version="13.0.0" />
+	</ItemGroup>
 
 </Project>

--- a/Commons/Common.Infrastructure/Common.Infrastructure.csproj
+++ b/Commons/Common.Infrastructure/Common.Infrastructure.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Common.Application\Common.Application.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Common.Application\Common.Application.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/Src/ShahanStore.Application/CQRS/Categories/Commands/AddChild/AddChildCategoryCommand.cs
+++ b/Src/ShahanStore.Application/CQRS/Categories/Commands/AddChild/AddChildCategoryCommand.cs
@@ -3,7 +3,8 @@ using Common.Domain.ValueObjects;
 
 namespace ShahanStore.Application.CQRS.Categories.Commands.AddChild;
 
-public sealed record AddChildCategoryCommand(string Title,
+public sealed record AddChildCategoryCommand(
+    string Title,
     string Slug,
     Guid ParentId,
     string? BannerImg,

--- a/Src/ShahanStore.Application/CQRS/Categories/Commands/AddChild/AddChildCategoryCommandHandler.cs
+++ b/Src/ShahanStore.Application/CQRS/Categories/Commands/AddChild/AddChildCategoryCommandHandler.cs
@@ -6,23 +6,23 @@ using ShahanStore.Domain.Categories;
 
 namespace ShahanStore.Application.CQRS.Categories.Commands.AddChild;
 
-internal class AddChildCategoryCommandHandler(ICategoryRepository categoryRepository, IUnitOfWork unitOfWork)
+internal sealed class AddChildCategoryCommandHandler(ICategoryRepository categoryRepository, IUnitOfWork unitOfWork)
     : ICommandHandler<AddChildCategoryCommand>
 {
     public async Task<OperationResult> Handle(AddChildCategoryCommand request, CancellationToken cancellationToken)
     {
-        var parentCategory = await categoryRepository.GetByIdAsync(request.ParentId);
+        var parentCategory = await categoryRepository.GetByIdAsync(request.ParentId,cancellationToken);
         if (parentCategory is null)
         {
             return OperationResult.NotFound();
         }
 
-        if (await categoryRepository.IsSlugDuplicateAsync(request.Slug.ToSlug()))
+        if (await categoryRepository.IsSlugDuplicateAsync(request.Slug.ToSlug(),cancellationToken))
         {
             return OperationResult.Error("اسلاگ وارد شده تکراری است.");
         }
 
-        var childCategory = new Category(request.Title, request.Slug, request.ParentId, request.BannerImg, request.Icon,
+        var childCategory = Category.CreateNew(request.Title, request.Slug, request.ParentId, request.BannerImg, request.Icon,
             request.SeoData);
 
         categoryRepository.Add(childCategory);

--- a/Src/ShahanStore.Application/CQRS/Categories/Commands/AddChild/AddChildCategoryCommandValidator.cs
+++ b/Src/ShahanStore.Application/CQRS/Categories/Commands/AddChild/AddChildCategoryCommandValidator.cs
@@ -3,7 +3,7 @@ using FluentValidation;
 
 namespace ShahanStore.Application.CQRS.Categories.Commands.AddChild;
 
-public class AddChildCategoryCommandValidator : AbstractValidator<AddChildCategoryCommand>
+public sealed class AddChildCategoryCommandValidator : AbstractValidator<AddChildCategoryCommand>
 {
     public AddChildCategoryCommandValidator()
     {

--- a/Src/ShahanStore.Application/CQRS/Categories/Commands/ChangeBanner/ChangeCategoryBannerCommandHandler.cs
+++ b/Src/ShahanStore.Application/CQRS/Categories/Commands/ChangeBanner/ChangeCategoryBannerCommandHandler.cs
@@ -5,12 +5,12 @@ using ShahanStore.Domain.Categories;
 
 namespace ShahanStore.Application.CQRS.Categories.Commands.ChangeBanner;
 
-internal class ChangeCategoryBannerCommandHandler(ICategoryRepository categoryRepository, IUnitOfWork unitOfWork)
+internal sealed class ChangeCategoryBannerCommandHandler(ICategoryRepository categoryRepository, IUnitOfWork unitOfWork)
     : ICommandHandler<ChangeCategoryBannerCommand>
 {
     public async Task<OperationResult> Handle(ChangeCategoryBannerCommand request, CancellationToken cancellationToken)
     {
-        var category = await categoryRepository.GetByIdAsync(request.CategoryId);
+        var category = await categoryRepository.GetByIdAsync(request.CategoryId, cancellationToken);
 
         if (category is null)
         {

--- a/Src/ShahanStore.Application/CQRS/Categories/Commands/ChangeBanner/ChangeCategoryBannerCommandValidator.cs
+++ b/Src/ShahanStore.Application/CQRS/Categories/Commands/ChangeBanner/ChangeCategoryBannerCommandValidator.cs
@@ -3,7 +3,7 @@ using FluentValidation;
 
 namespace ShahanStore.Application.CQRS.Categories.Commands.ChangeBanner;
 
-public class ChangeCategoryBannerCommandValidator : AbstractValidator<ChangeCategoryBannerCommand>
+public sealed class ChangeCategoryBannerCommandValidator : AbstractValidator<ChangeCategoryBannerCommand>
 {
     public ChangeCategoryBannerCommandValidator()
     {

--- a/Src/ShahanStore.Application/CQRS/Categories/Commands/ChangeIcon/ChangeCategoryIconCommandHandler.cs
+++ b/Src/ShahanStore.Application/CQRS/Categories/Commands/ChangeIcon/ChangeCategoryIconCommandHandler.cs
@@ -5,11 +5,11 @@ using ShahanStore.Domain.Categories;
 
 namespace ShahanStore.Application.CQRS.Categories.Commands.ChangeIcon;
 
-internal class ChangeCategoryIconCommandHandler(ICategoryRepository categoryRepository,IUnitOfWork unitOfWork) : ICommandHandler<ChangeCategoryIconCommand>
+internal sealed class ChangeCategoryIconCommandHandler(ICategoryRepository categoryRepository,IUnitOfWork unitOfWork) : ICommandHandler<ChangeCategoryIconCommand>
 {
     public async Task<OperationResult> Handle(ChangeCategoryIconCommand request, CancellationToken cancellationToken)
     {
-        var category = await categoryRepository.GetByIdAsync(request.CategoryId);
+        var category = await categoryRepository.GetByIdAsync(request.CategoryId, cancellationToken);
 
         if (category is null)
         {

--- a/Src/ShahanStore.Application/CQRS/Categories/Commands/ChangeIcon/ChangeCategoryIconCommandValidator.cs
+++ b/Src/ShahanStore.Application/CQRS/Categories/Commands/ChangeIcon/ChangeCategoryIconCommandValidator.cs
@@ -3,7 +3,7 @@ using FluentValidation;
 
 namespace ShahanStore.Application.CQRS.Categories.Commands.ChangeIcon;
 
-public class ChangeCategoryIconCommandValidator : AbstractValidator<ChangeCategoryIconCommand>
+public sealed class ChangeCategoryIconCommandValidator : AbstractValidator<ChangeCategoryIconCommand>
 {
     public ChangeCategoryIconCommandValidator()
     {

--- a/Src/ShahanStore.Application/CQRS/Categories/Commands/Create/CreateCategoryCommandHandler.cs
+++ b/Src/ShahanStore.Application/CQRS/Categories/Commands/Create/CreateCategoryCommandHandler.cs
@@ -6,17 +6,17 @@ using ShahanStore.Domain.Categories;
 
 namespace ShahanStore.Application.CQRS.Categories.Commands.Create;
 
-internal class CreateCategoryCommandHandler(ICategoryRepository categoryRepository, IUnitOfWork unitOfWork)
+internal sealed class CreateCategoryCommandHandler(ICategoryRepository categoryRepository, IUnitOfWork unitOfWork)
     : ICommandHandler<CreateCategoryCommand>
 {
     public async Task<OperationResult> Handle(CreateCategoryCommand request, CancellationToken cancellationToken)
     {
-        if (await categoryRepository.IsSlugDuplicateAsync(request.Slug.ToSlug()))
+        if (await categoryRepository.IsSlugDuplicateAsync(request.Slug.ToSlug(), cancellationToken))
         {
             return OperationResult.Error("اسلاگ وارد شده تکراری است.");
         }
 
-        var category = new Category(request.Title, request.Slug, null, request.BannerImg, request.Icon,
+        Category category=Category.CreateNew(request.Title, request.Slug, null, request.BannerImg, request.Icon,
             request.SeoData);
 
         categoryRepository.Add(category);

--- a/Src/ShahanStore.Application/CQRS/Categories/Commands/Create/CreateCategoryCommandValidator.cs
+++ b/Src/ShahanStore.Application/CQRS/Categories/Commands/Create/CreateCategoryCommandValidator.cs
@@ -3,7 +3,7 @@ using FluentValidation;
 
 namespace ShahanStore.Application.CQRS.Categories.Commands.Create;
 
-public class CreateCategoryCommandValidator : AbstractValidator<CreateCategoryCommand>
+public sealed class CreateCategoryCommandValidator : AbstractValidator<CreateCategoryCommand>
 {
     public CreateCategoryCommandValidator()
     {

--- a/Src/ShahanStore.Application/CQRS/Categories/Commands/Delete/DeleteCategoryCommand.cs
+++ b/Src/ShahanStore.Application/CQRS/Categories/Commands/Delete/DeleteCategoryCommand.cs
@@ -1,30 +1,5 @@
 ﻿using Common.Application.Abstractions.Messaging.Commands;
-using Common.Application.Models.Results;
-using Common.Domain.Repositories;
-using ShahanStore.Domain.Categories;
 
 namespace ShahanStore.Application.CQRS.Categories.Commands.Delete;
 
 public sealed record DeleteCategoryCommand(Guid CategoryId) : ICommand;
-
-internal class DeleteCategoryCommandHandler(ICategoryRepository categoryRepository, IUnitOfWork unitOfWork) :
-    ICommandHandler<DeleteCategoryCommand>
-{
-    public async Task<OperationResult> Handle(DeleteCategoryCommand request, CancellationToken cancellationToken)
-    {
-        var category = await categoryRepository.GetByIdAsync(request.CategoryId);
-        if (category is null)
-        {
-            return OperationResult.NotFound();
-        }
-
-        var children = await categoryRepository.GetAllChildrenAsync(request.CategoryId);
-        categoryRepository.Delete(category);
-        foreach (var child in children)
-        {
-            child.Delete();
-        }
-        await unitOfWork.SaveChangesAsync(cancellationToken);
-        return OperationResult.Success();
-    }
-}

--- a/Src/ShahanStore.Application/CQRS/Categories/Commands/Delete/DeleteCategoryCommandHandler.cs
+++ b/Src/ShahanStore.Application/CQRS/Categories/Commands/Delete/DeleteCategoryCommandHandler.cs
@@ -1,0 +1,28 @@
+﻿using Common.Application.Abstractions.Messaging.Commands;
+using Common.Application.Models.Results;
+using Common.Domain.Repositories;
+using ShahanStore.Domain.Categories;
+
+namespace ShahanStore.Application.CQRS.Categories.Commands.Delete;
+
+internal sealed class DeleteCategoryCommandHandler(ICategoryRepository categoryRepository, IUnitOfWork unitOfWork) :
+    ICommandHandler<DeleteCategoryCommand>
+{
+    public async Task<OperationResult> Handle(DeleteCategoryCommand request, CancellationToken cancellationToken)
+    {
+        var category = await categoryRepository.GetByIdAsync(request.CategoryId, cancellationToken);
+        if (category is null)
+        {
+            return OperationResult.NotFound();
+        }
+
+        var children = await categoryRepository.GetAllChildrenAsync(request.CategoryId, cancellationToken);
+        categoryRepository.Delete(category);
+        foreach (var child in children)
+        {
+            child.Delete();
+        }
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+        return OperationResult.Success();
+    }
+}

--- a/Src/ShahanStore.Application/CQRS/Categories/Commands/Edit/EditCategoryCommandHandler.cs
+++ b/Src/ShahanStore.Application/CQRS/Categories/Commands/Edit/EditCategoryCommandHandler.cs
@@ -6,11 +6,11 @@ using ShahanStore.Domain.Categories;
 
 namespace ShahanStore.Application.CQRS.Categories.Commands.Edit;
 
-internal class EditCategoryCommandHandler(ICategoryRepository categoryRepository, IUnitOfWork unitOfWork) : ICommandHandler<EditCategoryCommand>
+internal sealed class EditCategoryCommandHandler(ICategoryRepository categoryRepository, IUnitOfWork unitOfWork) : ICommandHandler<EditCategoryCommand>
 {
     public async Task<OperationResult> Handle(EditCategoryCommand request, CancellationToken cancellationToken)
     {
-        var category = await categoryRepository.GetByIdAsync(request.Id);
+        var category = await categoryRepository.GetByIdAsync(request.Id, cancellationToken);
         if (category is null)
         {
             return OperationResult.NotFound();
@@ -19,7 +19,7 @@ internal class EditCategoryCommandHandler(ICategoryRepository categoryRepository
         string newSlug = request.Slug.ToSlug();
         if (category.Slug != newSlug)
         {
-            if (await categoryRepository.IsSlugDuplicateAsync(request.Slug.ToSlug()))
+            if (await categoryRepository.IsSlugDuplicateAsync(request.Slug.ToSlug(), cancellationToken))
             {
                 return OperationResult.Error("اسلاگ وارد شده تکراری است.");
             }

--- a/Src/ShahanStore.Application/CQRS/Categories/Commands/Edit/EditCategoryCommandValidator.cs
+++ b/Src/ShahanStore.Application/CQRS/Categories/Commands/Edit/EditCategoryCommandValidator.cs
@@ -3,7 +3,7 @@ using FluentValidation;
 
 namespace ShahanStore.Application.CQRS.Categories.Commands.Edit;
 
-public class EditCategoryCommandValidator : AbstractValidator<EditCategoryCommand>
+public sealed class EditCategoryCommandValidator : AbstractValidator<EditCategoryCommand>
 {
     public EditCategoryCommandValidator()
     {

--- a/Src/ShahanStore.Application/CQRS/Categories/Queries/GetAll/GetAllCategoriesQueryHandler.cs
+++ b/Src/ShahanStore.Application/CQRS/Categories/Queries/GetAll/GetAllCategoriesQueryHandler.cs
@@ -4,11 +4,12 @@ using ShahanStore.Domain.Categories;
 
 namespace ShahanStore.Application.CQRS.Categories.Queries.GetAll;
 
-internal class GetAllCategoriesQueryHandler(ICategoryRepository repository) : IQueryHandler<GetAllCategoriesQuery, List<CategoryDto>>
+internal sealed class GetAllCategoriesQueryHandler(ICategoryRepository categoryRepository) : IQueryHandler<GetAllCategoriesQuery, List<CategoryDto>>
 {
+    private readonly ICategoryRepository _categoryRepository = categoryRepository;
     public async Task<List<CategoryDto>> Handle(GetAllCategoriesQuery request, CancellationToken cancellationToken)
     {
-        var categories = await repository.GetAllAsync();
+        var categories = await _categoryRepository.GetAllAsync(cancellationToken);
         return categories.Map();
     }
 }

--- a/Src/ShahanStore.Application/CQRS/Categories/Queries/GetById/GetCategoryByIdQueryHandler.cs
+++ b/Src/ShahanStore.Application/CQRS/Categories/Queries/GetById/GetCategoryByIdQueryHandler.cs
@@ -4,11 +4,12 @@ using ShahanStore.Domain.Categories;
 
 namespace ShahanStore.Application.CQRS.Categories.Queries.GetById;
 
-internal class GetCategoryByIdQueryHandler(ICategoryRepository repository) : IQueryHandler<GetCategoryByIdQuery, CategoryDto?>
+internal sealed class GetCategoryByIdQueryHandler(ICategoryRepository categoryRepository) : IQueryHandler<GetCategoryByIdQuery, CategoryDto?>
 {
+    private readonly ICategoryRepository _categoryRepository = categoryRepository;
     public async Task<CategoryDto?> Handle(GetCategoryByIdQuery request, CancellationToken cancellationToken)
     {
-        var category=await repository.GetByIdAsync(request.CategoryId);
+        var category=await _categoryRepository.GetByIdAsync(request.CategoryId, cancellationToken);
         return category.Map();
     }
 }

--- a/Src/ShahanStore.Application/CQRS/Categories/_Dtos/Commands/AddChildCategoryDto.cs
+++ b/Src/ShahanStore.Application/CQRS/Categories/_Dtos/Commands/AddChildCategoryDto.cs
@@ -1,0 +1,11 @@
+﻿using Common.Domain.ValueObjects;
+
+namespace ShahanStore.Application.CQRS.Categories._Dtos.Commands;
+
+public sealed record AddChildCategoryDto(
+    string Title,
+    string Slug,
+    Guid ParentId,
+    string? BannerImg,
+    string? Icon,
+    SeoData SeoData);

--- a/Src/ShahanStore.Application/CQRS/Categories/_Dtos/Commands/ChangeCategoryBannerDto.cs
+++ b/Src/ShahanStore.Application/CQRS/Categories/_Dtos/Commands/ChangeCategoryBannerDto.cs
@@ -1,0 +1,5 @@
+﻿namespace ShahanStore.Application.CQRS.Categories._Dtos.Commands;
+
+public sealed record ChangeCategoryBannerDto(
+    Guid CategoryId,
+    string BannerImg);

--- a/Src/ShahanStore.Application/CQRS/Categories/_Dtos/Commands/ChangeCategoryIconDto.cs
+++ b/Src/ShahanStore.Application/CQRS/Categories/_Dtos/Commands/ChangeCategoryIconDto.cs
@@ -1,0 +1,5 @@
+﻿namespace ShahanStore.Application.CQRS.Categories._Dtos.Commands;
+
+public sealed record ChangeCategoryIconDto(
+    Guid CategoryId,
+    string Icon);

--- a/Src/ShahanStore.Application/CQRS/Categories/_Dtos/Commands/CreateCategoryDto.cs
+++ b/Src/ShahanStore.Application/CQRS/Categories/_Dtos/Commands/CreateCategoryDto.cs
@@ -1,0 +1,10 @@
+﻿using Common.Application.Dtos;
+
+namespace ShahanStore.Application.CQRS.Categories._Dtos.Commands;
+
+public sealed record CreateCategoryDto(
+    string Title,
+    string Slug,
+    string? BannerImg,
+    string? Icon,
+    SeoDataDto SeoData);

--- a/Src/ShahanStore.Application/CQRS/Categories/_Dtos/Commands/DeleteCategoryDto.cs
+++ b/Src/ShahanStore.Application/CQRS/Categories/_Dtos/Commands/DeleteCategoryDto.cs
@@ -1,0 +1,3 @@
+﻿namespace ShahanStore.Application.CQRS.Categories._Dtos.Commands;
+
+public sealed record DeleteCategoryDto(Guid CategoryId);

--- a/Src/ShahanStore.Application/CQRS/Categories/_Dtos/Commands/EditCategoryDto.cs
+++ b/Src/ShahanStore.Application/CQRS/Categories/_Dtos/Commands/EditCategoryDto.cs
@@ -1,0 +1,9 @@
+﻿using Common.Domain.ValueObjects;
+
+namespace ShahanStore.Application.CQRS.Categories._Dtos.Commands;
+
+public sealed record EditCategoryDto(
+    Guid Id,
+    string Title,
+    string Slug,
+    SeoData SeoData);

--- a/Src/ShahanStore.Application/ShahanStore.Application.csproj
+++ b/Src/ShahanStore.Application/ShahanStore.Application.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\Commons\Common.Application\Common.Application.csproj" />
-    <ProjectReference Include="..\ShahanStore.Domain\ShahanStore.Domain.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\Commons\Common.Application\Common.Application.csproj" />
+		<ProjectReference Include="..\ShahanStore.Domain\ShahanStore.Domain.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/Src/ShahanStore.Domain/Categories/Category.cs
+++ b/Src/ShahanStore.Domain/Categories/Category.cs
@@ -13,15 +13,14 @@ public class Category : AggregateRoot
     public string? BannerImg { get; private set; }
     public string? Icon { get; private set; }
     public bool IsDeleted { get; private set; }
-    public SeoData SeoData { get; private set; } 
+    public SeoData SeoData { get; private set; }
 
     private readonly List<CategoryAttribute> _categoryAttributes = new();
     public IReadOnlyCollection<CategoryAttribute> CategoryAttributes => _categoryAttributes.AsReadOnly();
 
 
 
-    private Category() { }
-    public Category(string title, string slug, Guid? parentId, string? bannerImg, string? icon, SeoData seoData)
+    private Category(string title, string slug, Guid? parentId, string? bannerImg, string? icon, SeoData seoData)
     {
         Guard(title, slug);
         Title = title;
@@ -30,9 +29,18 @@ public class Category : AggregateRoot
         BannerImg = bannerImg;
         Icon = icon;
         SeoData = seoData;
-        IsDeleted= false;
+        IsDeleted = false;
+    }
+    public Category()
+    {
+        
     }
 
+
+    public static Category CreateNew(string title, string slug, Guid? parentId, string? bannerImg, string? icon, SeoData seoData)
+    {
+        return new Category(title, slug, parentId, bannerImg, icon, seoData);
+    }
     public void Edit(string title, string slug, SeoData seoData)
     {
         Guard(title, slug);

--- a/Src/ShahanStore.Domain/Categories/ICategoryRepository.cs
+++ b/Src/ShahanStore.Domain/Categories/ICategoryRepository.cs
@@ -4,10 +4,10 @@ namespace ShahanStore.Domain.Categories;
 
 public interface ICategoryRepository : IRepository<Category>
 {
-    Task<Category?> GetByIdAsync(Guid categoryId);
-    Task<List<Category>> GetAllAsync();
-    Task<List<Category>> GetAllChildrenAsync(Guid parentId);
+    Task<Category?> GetByIdAsync(Guid categoryId, CancellationToken cancellationToken);
+    Task<List<Category>> GetAllAsync(CancellationToken cancellationToken);
+    Task<List<Category>> GetAllChildrenAsync(Guid parentId, CancellationToken cancellationToken);
     void Add(Category category);
-    Task<bool> IsSlugDuplicateAsync(string slug);
+    Task<bool> IsSlugDuplicateAsync(string slug, CancellationToken cancellationToken);
     void Delete(Category category);
 }

--- a/Src/ShahanStore.Domain/ShahanStore.Domain.csproj
+++ b/Src/ShahanStore.Domain/ShahanStore.Domain.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\Commons\Common.Domain\Common.Domain.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\Commons\Common.Domain\Common.Domain.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/Src/ShahanStore.Infrastructure/Repositories/CategoryRepository.cs
+++ b/Src/ShahanStore.Infrastructure/Repositories/CategoryRepository.cs
@@ -6,30 +6,30 @@ namespace ShahanStore.Infrastructure.Repositories;
 
 public class CategoryRepository(AppDbContext context) : Repository<Category>(context), ICategoryRepository
 {
-    public async Task<Category?> GetByIdAsync(Guid categoryId)
+    public async Task<Category?> GetByIdAsync(Guid categoryId, CancellationToken cancellationToken)
     {
         return await Context.Categories
             .AsNoTracking()
-            .FirstOrDefaultAsync(c => c.Id == categoryId);
+            .FirstOrDefaultAsync(c => c.Id == categoryId, cancellationToken);
     }
 
-    public async Task<List<Category>> GetAllAsync()
+    public async Task<List<Category>> GetAllAsync(CancellationToken cancellationToken)
     {
-        return await Context.Categories.AsNoTracking().ToListAsync();
+        return await Context.Categories.AsNoTracking().ToListAsync(cancellationToken);
     }
 
-    public async Task<List<Category>> GetAllChildrenAsync(Guid parentId)
+    public async Task<List<Category>> GetAllChildrenAsync(Guid parentId, CancellationToken cancellationToken)
     {
         return await Context.Categories
             .Where(c => c.ParentId == parentId)
             .AsNoTracking()
-            .ToListAsync();
+            .ToListAsync(cancellationToken);
     }
 
-    public async Task<bool> IsSlugDuplicateAsync(string slug)
+    public async Task<bool> IsSlugDuplicateAsync(string slug, CancellationToken cancellationToken)
     {
         return await Context.Categories
-            .AnyAsync(c => c.Slug == slug);
+            .AnyAsync(c => c.Slug == slug, cancellationToken);
     }
 
     public void Delete(Category category)


### PR DESCRIPTION
This commit refactors the command-side of the Category feature to improve decoupling and asynchronous handling.

- Introduced `CreateCategoryDto` (and others) to act as a contract for the API layer, separating it from the internal `CreateCategoryCommand`.
- Updated the `CategoriesController` to accept the DTO and handle the mapping to the command.
- Added `CancellationToken` to all asynchronous methods in `ICategoryRepository` and its implementation to support request cancellation.